### PR TITLE
Adds armhf image support.

### DIFF
--- a/euca2ools/commands/euca/bundleimage.py
+++ b/euca2ools/commands/euca/bundleimage.py
@@ -81,7 +81,7 @@ class BundleImage(euca2ools.commands.eucacommand.EucaCommand):
                Param(name='target_arch',
                      short_name='r', long_name='arch',
                      optional=True, ptype='string', default='x86_64',
-                     choices=['i386', 'x86_64'],
+                     choices=['i386', 'x86_64', 'armhf'],
                      doc='Target architecture for the image.'),
                Param(name='batch', long_name='batch',
                      optional=True, ptype='boolean',

--- a/euca2ools/commands/euca/bundleupload.py
+++ b/euca2ools/commands/euca/bundleupload.py
@@ -86,7 +86,7 @@ class BundleUpload(UploadBundle, BundleImage):
                Param(name='target_arch',
                      short_name='r', long_name='arch',
                      optional=True, ptype='string', default='x86_64',
-                     choices=['i386', 'x86_64'],
+                     choices=['i386', 'x86_64', 'armhf'],
                      doc='Target architecture for the image.'),
                Param(name='acl', long_name='acl',
                      optional=True, ptype='string', default='ec2-bundle-read',

--- a/euca2ools/commands/euca/bundlevol.py
+++ b/euca2ools/commands/euca/bundlevol.py
@@ -98,7 +98,7 @@ class BundleVol(euca2ools.commands.eucacommand.EucaCommand):
                Param(name='target_architecture',
                      short_name='r', long_name='arch',
                      optional=True, ptype='string', default='x86_64',
-                     choices=['i386', 'x86_64'],
+                     choices=['i386', 'x86_64', 'armhf'],
                      doc='Target architecture for the image'),
                Param(name='volume_path', long_name='volume',
                      optional=True, ptype='dir', default='/',

--- a/euca2ools/commands/euca/describeimages.py
+++ b/euca2ools/commands/euca/describeimages.py
@@ -54,7 +54,7 @@ class DescribeImages(euca2ools.commands.eucacommand.EucaCommand):
     Args = [Param(name='image', ptype='string',
                   cardinality='+', optional=True)]
     Filters = [Param(name='architecture', ptype='string',
-                     doc='Image architecture.  Valid values are i386 | x86_64'),
+                     doc='Image architecture.  Valid values are i386 | x86_64 | armhf'),
                Param(name='block-device-mapping.delete-on-termination',
                      ptype='boolean',
                      doc="""Whether the Amazon EBS volume is deleted on

--- a/euca2ools/commands/euca/describeinstances.py
+++ b/euca2ools/commands/euca/describeinstances.py
@@ -43,7 +43,7 @@ class DescribeInstances(euca2ools.commands.eucacommand.EucaCommand):
                   cardinality='+', optional=True)]
     Filters = [Param(name='architecture', ptype='string',
                      doc="""Instance architecture.
-                     Valid values are i386 | x86_64"""),
+                     Valid values are i386 | x86_64 | armhf"""),
                Param(name='availability-zone', ptype='string',
                      doc="Instance's Availability Zone"),
                Param(name='block-device-mapping.attach-time',

--- a/euca2ools/commands/euca/register.py
+++ b/euca2ools/commands/euca/register.py
@@ -53,7 +53,7 @@ class Register(euca2ools.commands.eucacommand.EucaCommand):
                Param(name='architecture',
                      short_name='a', long_name='architecture',
                      optional=True, ptype='string', default='i386',
-                     choices=['i386', 'x86_64'],
+                     choices=['i386', 'x86_64', 'armhf'],
                      doc='The architecture of the image.'),
                Param(name='kernel', long_name='kernel',
                      optional=True, ptype='string',

--- a/man/euca-bundle-image.1
+++ b/man/euca-bundle-image.1
@@ -96,7 +96,7 @@ certificate.
 .TP
 \fB\-r\fR,\-\-arch
 Target architecture for the image.
-Valid Values: i386|x86_64
+Valid Values: i386|x86_64|armhf
 .TP
 \fB\-\-batch\fR
 Run in batch mode.  Compatibility only, has no

--- a/man/euca-bundle-upload.1
+++ b/man/euca-bundle-upload.1
@@ -97,7 +97,7 @@ Default block device mapping for the image
 .TP
 \fB\-r\fR,\-\-arch
 Target architecture for the image.
-Valid Values: i386|x86_64
+Valid Values: i386|x86_64|armhf
 .TP
 \fB\-\-acl\fR
 Canned ACL policy

--- a/man/euca-bundle-vol.1
+++ b/man/euca-bundle-vol.1
@@ -106,7 +106,7 @@ certificate.
 .TP
 \fB\-r\fR,\-\-arch
 Target architecture for the image
-Valid Values: i386|x86_64
+Valid Values: i386|x86_64|armhf
 .TP
 \fB\-\-volume\fR
 Path to mounted volume to bundle.

--- a/man/euca-describe-images.1
+++ b/man/euca-describe-images.1
@@ -63,7 +63,7 @@ AVAILABLE FILTERS
 .TP
 architecture
 Image architecture.  Valid values are i386 |
-x86_64
+x86_64 | armhf
 .IP
 block\-device\-mapping.delete\-on\-terminationWhether the Amazon EBS volume is deleted on
 .IP

--- a/man/euca-describe-instances.1
+++ b/man/euca-describe-instances.1
@@ -49,7 +49,7 @@ AVAILABLE FILTERS
 .TP
 architecture
 Instance architecture.
-Valid values are i386 | x86_64
+Valid values are i386 | x86_64 | armhf
 .TP
 availability\-zone
 Instance's Availability Zone

--- a/man/euca-register.1
+++ b/man/euca-register.1
@@ -61,7 +61,7 @@ Name of the image.
 .TP
 \fB\-a\fR,\-\-architecture
 The architecture of the image.
-Valid Values: i386|x86_64
+Valid Values: i386|x86_64|armhf
 .TP
 \fB\-\-kernel\fR
 The ID of the kernel associated with the


### PR DESCRIPTION
cloud-images.ubuntu.com have been offering armhf images
for a while now. This patch adds support for armhf to the euca2ools
manifests.

Signed-off-by: Chuck Short chuck.short@canonical.com
