### PR TITLE
Add a way to save private keyfiles with euca-create-keypair

### DIFF
--- a/euca2ools/commands/euca/createkeypair.py
+++ b/euca2ools/commands/euca/createkeypair.py
@@ -49,8 +49,10 @@ class CreateKeyPair(euca2ools.commands.eucacommand.EucaCommand):
                   doc='unique name for a keypair to be created',
                   cardinality=1, optional=False)]
 
-    def display_keypair(self, keypair):
+    def display_fingerprint(self, keypair):
         print 'KEYPAIR\t%s\t%s' % (keypair.name, keypair.fingerprint)
+
+    def display_keypair(self, keypair):
         print keypair.material
 
     def save_keypair_to_file(self, keypair):
@@ -67,7 +69,9 @@ class CreateKeyPair(euca2ools.commands.eucacommand.EucaCommand):
 
     def main_cli(self):
         keypair = self.main()
-        self.display_keypair(keypair)
+        self.display_fingerprint(keypair)
         if self.filename != None:
             self.save_keypair_to_file(keypair)
+        else:
+            self.display_keypair(keypair)
 


### PR DESCRIPTION
- Added a -f <filename> flag to allow the user to enter a filename for the private key.
- Private key is saved to the filename provided and is the file permissions are changed to 0600 so that the key is ready to use.
