### PR TITLE
Added additional field to eustore-describe-images

### DIFF
--- a/euca2ools/commands/eustore/describeimages.py
+++ b/euca2ools/commands/eustore/describeimages.py
@@ -80,6 +80,7 @@ class DescribeImages(AWSQueryRequest):
                       self.fmtCol(image['os'],12)+ \
                       self.fmtCol(image['architecture'],8)+ \
                       self.fmtCol(image['version'],15)+ \
+                      self.fmtCol(', '.join(image['hypervisors-supported']),18)+ \
                       image['description']
                 if self.cli_options.verbose:
                     print "     "+self.fmtCol(image['date'],20)+ \


### PR DESCRIPTION
Added 'hypervisors-supported' to standard output of eustore-describe-images.  Now default eustore-describe-images looks similar to the following:

<code>
# eustore-describe-images

0941572954 fedora      x86_64  experimental   kvm               Fedora 16 x86_64 - unsecure, SELinux / iptables disabled. Root disk of 4.5G. Root user enabled.
1765088432 fedora      x86_64  experimental   kvm               Fedora 17 x86_64 - unsecure, SELinux / iptables disabled. Root disk of 4.5G. Root user enabled.
1107385945 centos      x86_64  starter        xen, kvm, vmware  CentOS 5 1.3GB root, Hypervisor-Specific Kernels
3868652036 centos      x86_64  experimental   kvm               CentOS 6.3 x86_64 - unsecure, SELinux / iptables disabled. Root disk of 4.5G. Root user enable. It works w/ kexec kernel.
</code>
