### PR TITLE
Bundle uses a logger it doesn't have

### DIFF
--- a/euca2ools/commands/bundle/bundle.py
+++ b/euca2ools/commands/bundle/bundle.py
@@ -31,6 +31,7 @@
 import hashlib
 import multiprocessing
 import itertools
+import logging
 import os.path
 import random
 import subprocess
@@ -55,6 +56,7 @@ class Bundle(object):
         self.enc_iv = None  # a hex string
         self.image_filename = None
         self.image_size = None
+        self.log = logging.getLogger("Bundle")
         self.parts = None
         self._lock = threading.Lock()
 


### PR DESCRIPTION
Added a logger to the class. That's all. Fixes an exception thrown when trying to log about the image being really big.
