### PR TITLE
owner-id filter does not work with euca-describe-groups

### DIFF
--- a/euca2ools/commands/euca/describesecuritygroups.py
+++ b/euca2ools/commands/euca/describesecuritygroups.py
@@ -50,7 +50,7 @@ class DescribeSecurityGroups(EucalyptusRequest):
                       help='end of TCP/UDP port range, or ICMP code'),
                Filter('ip-permission.user-id',
                       help='ID of an account granted permission'),
-               Filter('owner-id', help=="account ID of the group's owner"),
+               Filter('owner-id', help="account ID of the group's owner"),
                Filter('tag-key', help='key of a tag assigned to the group'),
                Filter('tag-value',
                       help='value of a tag assigned to the group'),


### PR DESCRIPTION
Please check https://eucalyptus.atlassian.net/browse/TOOLS-354 for more details. Does this make sense ? This would also fix the help output that comes in euca-describe-groups --help
