### PR TITLE
Remove wrapping ServerCertificateMetadata

### DIFF
--- a/euca2ools/commands/euare/listservercertificates.py
+++ b/euca2ools/commands/euare/listservercertificates.py
@@ -50,4 +50,4 @@ class ListServerCertificates(EuareRequest):
 
     def print_result(self, result):
         for cert in result.get('ServerCertificateMetadataList', []):
-            print cert['ServerCertificateMetadata']['Arn']
+            print cert['Arn']


### PR DESCRIPTION
The example in AWS api DOC is inconsistent with it's actual behavior.  
http://docs.aws.amazon.com/IAM/latest/APIReference/API_ListServerCertificates.html
