### PR TITLE
euca-bundle-vol ignores all ".*' files in / while building rsync command

### DIFF
--- a/euca2ools/commands/bundle/imagecreator.py
+++ b/euca2ools/commands/bundle/imagecreator.py
@@ -255,7 +255,7 @@ class VolumeSync(object):
             cmd.extend(['--exclude', exclude])
         for include in self.includes:
             cmd.extend(['--include', include])
-        cmd.extend(glob.glob(os.path.join(self.volume, '*')))
+        cmd.extend([os.path.join(self.volume, p) for p in os.listdir(self.volume)])
         cmd.append(self.mpoint + os.path.sep)
 
         try:


### PR DESCRIPTION
re-submit https://github.com/eucalyptus/euca2ools/pull/41 for 3.0-maint
