### PR TITLE
Added fix to uploadservercertificate.py for missing 'type' option 

### DIFF
--- a/euca2ools/commands/iam/uploadservercertificate.py
+++ b/euca2ools/commands/iam/uploadservercertificate.py
@@ -53,7 +53,8 @@ class UploadServerCertificate(IAMRequest):
                     This is typically the PEM-encoded certificates of the
                     chain, concatenated together.'''),
                 Arg('--certificate-chain-file', dest='CertificateChain',
-                    metavar='FILE', help='''file containing the PEM-encoded
+                    metavar='FILE', type=open,
+                    help='''file containing the PEM-encoded
                     certificate chain. This is typically the PEM-encoded
                     certificates of the chain, concatenated together.''')),
             Arg('-p', '--path', dest='Path',


### PR DESCRIPTION
['--certificate-chain-file'](https://github.com/eucalyptus/euca2ools/blob/master/euca2ools/commands/iam/uploadservercertificate.py#L50-L58) missing "type=open" option. 