### PR TITLE
IAM account creation without name

### DIFF
--- a/euca2ools/commands/iam/createaccount.py
+++ b/euca2ools/commands/iam/createaccount.py
@@ -31,8 +31,7 @@ from requestbuilder.mixins import TabifyingMixin
 class CreateAccount(IAMRequest, TabifyingMixin):
     DESCRIPTION = '[Eucalyptus cloud admin only] Create a new account'
     ARGS = [Arg('-a', '--account-name', dest='AccountName', metavar='ACCOUNT',
-                required=True,
-                help='name of the account to create (required)')]
+                help='name (alias) of the account to create')]
 
     def print_result(self, result):
         print self.tabify((result.get('Account', {}).get('AccountName'),


### PR DESCRIPTION
Allow account creation without a specified alias, relates to the Eucalyptus 4.2. story:

https://eucalyptus.atlassian.net/browse/EUCA-10738