### PR TITLE
Add ppc64le (ppc64 Little-Endian) as supported architecture

### DIFF
--- a/euca2ools/commands/bundle/bundlevolume.py
+++ b/euca2ools/commands/bundle/bundlevolume.py
@@ -63,7 +63,7 @@ class BundleVolume(BaseCommand, FileTransferProgressBarMixin):
             # -r/--arch is required, but to keep the UID check we do at the
             # beginning of configure() first we enforce that there instead.
             Arg('-r', '--arch', help="the image's architecture (required)",
-                choices=('i386', 'x86_64', 'armhf', 'ppc', 'ppc64')),
+                choices=('i386', 'x86_64', 'armhf', 'ppc', 'ppc64', 'ppc64le')),
             Arg('-e', '--exclude', metavar='PATH,...',
                 type=delimited_list(','),
                 help='comma-separated list of paths to exclude'),

--- a/euca2ools/commands/bundle/mixins.py
+++ b/euca2ools/commands/bundle/mixins.py
@@ -63,7 +63,7 @@ class BundleCreatingMixin(object):
                 the bundle's files (default:  dir named by TMPDIR, TEMP, or TMP
                 environment variables, or otherwise /var/tmp)'''),
             Arg('-r', '--arch', required=True,
-                choices=('i386', 'x86_64', 'armhf', 'ppc', 'ppc64'),
+                choices=('i386', 'x86_64', 'armhf', 'ppc', 'ppc64', 'ppc64le'),
                 help="the image's architecture (required)"),
 
             # User- and cloud-specific stuff


### PR DESCRIPTION
Devstack fails for ppc64le cirros image:
euca-bundle-image: error: argument -r/--arch: invalid choice:
'ppc64le' (choose from 'i386', 'x86_64', 'armhf', 'ppc', 'ppc64')

Closes-bug: #1527341