### PR TITLE
Fix display of network interface attachment identifier

### DIFF
--- a/euca2ools/commands/ec2/__init__.py
+++ b/euca2ools/commands/ec2/__init__.py
@@ -280,7 +280,7 @@ class EC2Request(AWSQueryRequest, TabifyingMixin):
         print self.tabify(['NETWORKINTERFACE'] + nic_info)
         if nic.get('attachment'):
             attachment_info = [nic['attachment'].get(attr) for attr in (
-                'attachmentID', 'deviceIndex', 'status', 'attachTime',
+                'attachmentId', 'deviceIndex', 'status', 'attachTime',
                 'deleteOnTermination')]
             print self.tabify(['ATTACHMENT'] + attachment_info)
         privaddresses = nic.get('privateIpAddressesSet', [])


### PR DESCRIPTION
Fix case for attachment identifier output with euca-describe-network-interfaces.

http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkInterfaces.html
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_NetworkInterface.html
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_NetworkInterfaceAttachment.html