### PR TITLE
Support ENI count for instance types

### DIFF
--- a/euca2ools/commands/ec2/describeinstancetypes.py
+++ b/euca2ools/commands/ec2/describeinstancetypes.py
@@ -54,6 +54,8 @@ class DescribeInstanceTypes(EC2Request, TabifyingMixin):
             vmtypes[vmtype['name']] = {'cpu': vmtype.get('cpu'),
                                        'memory': vmtype.get('memory'),
                                        'disk': vmtype.get('disk'),
+                                       'networkInterfaces':
+                                         vmtype.get('networkInterfaces'),
                                        'available': 0,
                                        'max': 0}
             if self.params.get('Availability', False):
@@ -84,6 +86,7 @@ class DescribeInstanceTypes(EC2Request, TabifyingMixin):
                   'cpu': 'CPUs',
                   'memory': 'Memory (MiB)',
                   'disk': 'Disk (GiB)',
+                  'networkInterfaces': 'ENIs',
                   'used': 'Used',
                   'total': 'Total',
                   'used_pct': 'Used %'}
@@ -101,6 +104,8 @@ class DescribeInstanceTypes(EC2Request, TabifyingMixin):
                            'cpu': vmtypes[vmtype_name].get('cpu'),
                            'memory': vmtypes[vmtype_name].get('memory'),
                            'disk': vmtypes[vmtype_name].get('disk'),
+                           'networkInterfaces':
+                             vmtypes[vmtype_name].get('networkInterfaces'),
                            'used': used,
                            'total': total,
                            'used_pct': used_pct}
@@ -109,7 +114,8 @@ class DescribeInstanceTypes(EC2Request, TabifyingMixin):
                 if len(str(vmtype_info[field])) > field_lengths[field]:
                     field_lengths[field] = len(str(vmtype_info[field]))
         type_template = ('{{name:<{name}}}  {{cpu:>{cpu}}}  '
-                         '{{memory:>{memory}}}  {{disk:>{disk}}}')
+                         '{{memory:>{memory}}}  {{disk:>{disk}}}  '
+                         '{{networkInterfaces:>{networkInterfaces}}}')
         if self.args.get('Availability', False):
             type_template += ('  {{used:>{used}}} / {{total:>{total}}}  '
                               '{{used_pct:>{used_pct}}}')

--- a/euca2ools/commands/ec2/modifyinstancetypeattribute.py
+++ b/euca2ools/commands/ec2/modifyinstancetypeattribute.py
@@ -40,6 +40,8 @@ class ModifyInstanceTypeAttribute(EC2Request, TabifyingMixin):
                 help='amount of instance storage to allow each instance'),
             Arg('-m', '--memory', dest='Memory', metavar='MiB', type=int,
                 help='amount of RAM to allocate to each instance'),
+            Arg('-i', '--network-interfaces', dest='NetworkInterfaces', metavar='COUNT', type=int,
+                help='maximum network interfaces for each instance (VPC)'),
             Arg('--reset', dest='Reset', action='store_true',
                 help='reset the instance type to its default configuration')]
 
@@ -57,4 +59,4 @@ class ModifyInstanceTypeAttribute(EC2Request, TabifyingMixin):
         newtype = result.get('instanceType', {})
         print self.tabify(('INSTANCETYPE', newtype.get('name'),
                            newtype.get('cpu'), newtype.get('memory'),
-                           newtype.get('disk')))
+                           newtype.get('disk'), newtype.get('networkInterfaces')))


### PR DESCRIPTION
EUCA-11909 adds support for instance types defining a maximum network interfaces attribute. This pull request allows the new attribute to be displayed and modified.

This may need some updates before being suitable for merge (formatting, parameter names, etc)