### PR TITLE
Add option for preventing address reassociation

### DIFF
--- a/euca2ools/commands/ec2/associateaddress.py
+++ b/euca2ools/commands/ec2/associateaddress.py
@@ -47,10 +47,15 @@ class AssociateAddress(EC2Request):
                 metavar='ADDRESS', help='''[VPC only] the private address to
                 associate with the address being associated in the VPC
                 (default: primary private IP)'''),
-            Arg('--allow-reassociation', dest='AllowReassociation',
-                action='store_const', const='true',
-                help='''[VPC only] allow the address to be associated even if
-                it is already associated with another interface''')]
+            MutuallyExclusiveArgList(
+                Arg('--allow-reassociation', dest='AllowReassociation',
+                    action='store_const', const='true',
+                    help='''[VPC only] allow the address to be associated even
+                    if it is already associated with another interface'''),
+                Arg('--no-allow-reassociation', dest='AllowReassociation',
+                    action='store_const', const='false',
+                    help='''[VPC only] do not allow the address to be associated
+                    if it is already associated with another interface'''))]
 
     # noinspection PyExceptionInherit
     def configure(self):


### PR DESCRIPTION
On some platforms the default behaviour is to allow address reassocation. When this is the case an option to forbid reassociation of an address may be useful.