### PR TITLE
Add a -j/--json option for euca-describe-* commands

### DIFF
--- a/euca2ools/commands/ec2/__init__.py
+++ b/euca2ools/commands/ec2/__init__.py
@@ -73,15 +73,14 @@ class EC2Request(AWSQueryRequest, TabifyingMixin):
     AUTH_CLASS = requestbuilder.auth.aws.HmacV4Auth
     METHOD = 'POST'
 
-    ARGS = [Arg('-j', '--json',
-                action='store_const', const='true', route_to=None,
-                help='''Output in json format''')]
+    ARGS = [Arg('--pretty', choices=('json',), route_to=None,
+                help='''Pretty print output format''')]
 
     def __init__(self, **kwargs):
         AWSQueryRequest.__init__(self, **kwargs)
 
     def print_result(self, result):
-        if self.args.get('json'):
+        if self.args.get('pretty') == 'json':
             print json.dumps(result, sort_keys=True, indent=2)
         else:
             self.print_result_native(result)

--- a/euca2ools/commands/ec2/__init__.py
+++ b/euca2ools/commands/ec2/__init__.py
@@ -25,6 +25,7 @@
 
 import argparse
 import io
+import json
 from operator import itemgetter
 import os.path
 import socket
@@ -72,14 +73,18 @@ class EC2Request(AWSQueryRequest, TabifyingMixin):
     AUTH_CLASS = requestbuilder.auth.aws.HmacV4Auth
     METHOD = 'POST'
 
-    ARGS = [
-            Arg('-j', '--json',
+    ARGS = [Arg('-j', '--json',
                 action='store_const', const='true', route_to=None,
-                help='''Output in json format''')
-            ]
+                help='''Output in json format''')]
 
     def __init__(self, **kwargs):
         AWSQueryRequest.__init__(self, **kwargs)
+
+    def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2) 
+        else:
+            self.print_result_native(result)
 
     def print_resource_tag(self, resource_tag, resource_id):
         resource_type = RESOURCE_TYPE_MAP.lookup(resource_id)

--- a/euca2ools/commands/ec2/__init__.py
+++ b/euca2ools/commands/ec2/__init__.py
@@ -81,9 +81,21 @@ class EC2Request(AWSQueryRequest, TabifyingMixin):
 
     def print_result(self, result):
         if self.args.get('pretty') == 'json':
-            print json.dumps(result, sort_keys=True, indent=2)
+            self.print_result_json(result)
         else:
-            self.print_result_native(result)
+            self.print_result_plain(result)
+
+    def print_result_json(self, result):
+        '''
+        Pretty print result in json format
+        '''
+        print json.dumps(result, sort_keys=True, indent=2)
+
+    def print_result_plain(self, result):
+        '''
+        Print result in plain format (default)
+        '''
+        pass
 
     def print_resource_tag(self, resource_tag, resource_id):
         resource_type = RESOURCE_TYPE_MAP.lookup(resource_id)

--- a/euca2ools/commands/ec2/__init__.py
+++ b/euca2ools/commands/ec2/__init__.py
@@ -74,7 +74,7 @@ class EC2Request(AWSQueryRequest, TabifyingMixin):
     METHOD = 'POST'
 
     ARGS = [Arg('--pretty', choices=('json',), route_to=None,
-                help='''Pretty print output format''')]
+                help='''pretty print output format''')]
 
     def __init__(self, **kwargs):
         AWSQueryRequest.__init__(self, **kwargs)

--- a/euca2ools/commands/ec2/__init__.py
+++ b/euca2ools/commands/ec2/__init__.py
@@ -82,7 +82,7 @@ class EC2Request(AWSQueryRequest, TabifyingMixin):
 
     def print_result(self, result):
         if self.args.get('json'):
-            print json.dumps(result, sort_keys=True, indent=2) 
+            print json.dumps(result, sort_keys=True, indent=2)
         else:
             self.print_result_native(result)
 

--- a/euca2ools/commands/ec2/__init__.py
+++ b/euca2ools/commands/ec2/__init__.py
@@ -81,7 +81,7 @@ class EC2Request(AWSQueryRequest, TabifyingMixin):
         AWSQueryRequest.__init__(self, **kwargs)
 
     def print_result(self, result):
-        if self.args['json']:
+        if self.args.get('json'):
             print json.dumps(result, sort_keys=True, indent=2) 
         else:
             self.print_result_native(result)

--- a/euca2ools/commands/ec2/__init__.py
+++ b/euca2ools/commands/ec2/__init__.py
@@ -72,6 +72,12 @@ class EC2Request(AWSQueryRequest, TabifyingMixin):
     AUTH_CLASS = requestbuilder.auth.aws.HmacV4Auth
     METHOD = 'POST'
 
+    ARGS = [
+            Arg('-j', '--json',
+                action='store_const', const='true', route_to=None,
+                help='''Output in json format''')
+            ]
+
     def __init__(self, **kwargs):
         AWSQueryRequest.__init__(self, **kwargs)
 

--- a/euca2ools/commands/ec2/describeaccountattributes.py
+++ b/euca2ools/commands/ec2/describeaccountattributes.py
@@ -34,7 +34,7 @@ class DescribeAccountAttributes(EC2Request):
                 help='limit results to specific account attributes')]
     LIST_TAGS = ['accountAttributeSet', 'attributeValueSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for attr in result.get('accountAttributeSet') or []:
             print self.tabify(('ACCOUNTATTRIBUTE', attr.get('attributeName')))
             for value in attr.get('attributeValueSet') or []:

--- a/euca2ools/commands/ec2/describeaccountattributes.py
+++ b/euca2ools/commands/ec2/describeaccountattributes.py
@@ -27,7 +27,6 @@ from requestbuilder import Arg
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeAccountAttributes(EC2Request):
     DESCRIPTION = 'Show information about your account'
@@ -35,10 +34,7 @@ class DescribeAccountAttributes(EC2Request):
                 help='limit results to specific account attributes')]
     LIST_TAGS = ['accountAttributeSet', 'attributeValueSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for attr in result.get('accountAttributeSet') or []:
             print self.tabify(('ACCOUNTATTRIBUTE', attr.get('attributeName')))
             for value in attr.get('attributeValueSet') or []:

--- a/euca2ools/commands/ec2/describeaccountattributes.py
+++ b/euca2ools/commands/ec2/describeaccountattributes.py
@@ -27,6 +27,7 @@ from requestbuilder import Arg
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeAccountAttributes(EC2Request):
     DESCRIPTION = 'Show information about your account'
@@ -35,6 +36,9 @@ class DescribeAccountAttributes(EC2Request):
     LIST_TAGS = ['accountAttributeSet', 'attributeValueSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for attr in result.get('accountAttributeSet') or []:
             print self.tabify(('ACCOUNTATTRIBUTE', attr.get('attributeName')))
             for value in attr.get('attributeValueSet') or []:

--- a/euca2ools/commands/ec2/describeaddresses.py
+++ b/euca2ools/commands/ec2/describeaddresses.py
@@ -26,7 +26,6 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter
 
-import json
 
 class DescribeAddresses(EC2Request):
     DESCRIPTION = 'Show information about elastic IP addresses'
@@ -57,10 +56,7 @@ class DescribeAddresses(EC2Request):
         if public_ips:
             self.params['PublicIp'] = list(sorted(public_ips))
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for addr in result.get('addressesSet', []):
             print self.tabify(('ADDRESS', addr.get('publicIp'),
                                addr.get('instanceId'),

--- a/euca2ools/commands/ec2/describeaddresses.py
+++ b/euca2ools/commands/ec2/describeaddresses.py
@@ -26,6 +26,7 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter
 
+import json
 
 class DescribeAddresses(EC2Request):
     DESCRIPTION = 'Show information about elastic IP addresses'
@@ -57,6 +58,9 @@ class DescribeAddresses(EC2Request):
             self.params['PublicIp'] = list(sorted(public_ips))
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for addr in result.get('addressesSet', []):
             print self.tabify(('ADDRESS', addr.get('publicIp'),
                                addr.get('instanceId'),

--- a/euca2ools/commands/ec2/describeaddresses.py
+++ b/euca2ools/commands/ec2/describeaddresses.py
@@ -56,7 +56,7 @@ class DescribeAddresses(EC2Request):
         if public_ips:
             self.params['PublicIp'] = list(sorted(public_ips))
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for addr in result.get('addressesSet', []):
             print self.tabify(('ADDRESS', addr.get('publicIp'),
                                addr.get('instanceId'),

--- a/euca2ools/commands/ec2/describeavailabilityzones.py
+++ b/euca2ools/commands/ec2/describeavailabilityzones.py
@@ -39,7 +39,7 @@ class DescribeAvailabilityZones(EC2Request):
                Filter('zone-name', help='name of the availability zone')]
     LIST_TAGS = ['availabilityZoneInfo', 'messageSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for zone in result.get('availabilityZoneInfo', []):
             msgs = ', '.join(msg for msg in zone.get('messageSet', []))
             print self.tabify(('AVAILABILITYZONE', zone.get('zoneName'),

--- a/euca2ools/commands/ec2/describeavailabilityzones.py
+++ b/euca2ools/commands/ec2/describeavailabilityzones.py
@@ -26,8 +26,6 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter
 
-import json
-
 
 class DescribeAvailabilityZones(EC2Request):
     DESCRIPTION = 'Display availability zones within the current region'
@@ -41,10 +39,7 @@ class DescribeAvailabilityZones(EC2Request):
                Filter('zone-name', help='name of the availability zone')]
     LIST_TAGS = ['availabilityZoneInfo', 'messageSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for zone in result.get('availabilityZoneInfo', []):
             msgs = ', '.join(msg for msg in zone.get('messageSet', []))
             print self.tabify(('AVAILABILITYZONE', zone.get('zoneName'),

--- a/euca2ools/commands/ec2/describeavailabilityzones.py
+++ b/euca2ools/commands/ec2/describeavailabilityzones.py
@@ -26,6 +26,8 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter
 
+import json
+
 
 class DescribeAvailabilityZones(EC2Request):
     DESCRIPTION = 'Display availability zones within the current region'
@@ -40,6 +42,9 @@ class DescribeAvailabilityZones(EC2Request):
     LIST_TAGS = ['availabilityZoneInfo', 'messageSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for zone in result.get('availabilityZoneInfo', []):
             msgs = ', '.join(msg for msg in zone.get('messageSet', []))
             print self.tabify(('AVAILABILITYZONE', zone.get('zoneName'),

--- a/euca2ools/commands/ec2/describebundletasks.py
+++ b/euca2ools/commands/ec2/describebundletasks.py
@@ -46,6 +46,6 @@ class DescribeBundleTasks(EC2Request):
                Filter('update-time', help='most recent task update time')]
     LIST_TAGS = ['bundleInstanceTasksSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for task in result.get('bundleInstanceTasksSet', []):
             self.print_bundle_task(task)

--- a/euca2ools/commands/ec2/describebundletasks.py
+++ b/euca2ools/commands/ec2/describebundletasks.py
@@ -26,6 +26,7 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter
 
+import json
 
 class DescribeBundleTasks(EC2Request):
     DESCRIPTION = 'Describe current instance-bundling tasks'
@@ -47,5 +48,8 @@ class DescribeBundleTasks(EC2Request):
     LIST_TAGS = ['bundleInstanceTasksSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for task in result.get('bundleInstanceTasksSet', []):
             self.print_bundle_task(task)

--- a/euca2ools/commands/ec2/describebundletasks.py
+++ b/euca2ools/commands/ec2/describebundletasks.py
@@ -26,7 +26,6 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter
 
-import json
 
 class DescribeBundleTasks(EC2Request):
     DESCRIPTION = 'Describe current instance-bundling tasks'
@@ -47,9 +46,6 @@ class DescribeBundleTasks(EC2Request):
                Filter('update-time', help='most recent task update time')]
     LIST_TAGS = ['bundleInstanceTasksSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for task in result.get('bundleInstanceTasksSet', []):
             self.print_bundle_task(task)

--- a/euca2ools/commands/ec2/describeconversiontasks.py
+++ b/euca2ools/commands/ec2/describeconversiontasks.py
@@ -26,6 +26,7 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg
 
+import json
 
 class DescribeConversionTasks(EC2Request):
     DESCRIPTION = 'Show information about import operations'
@@ -34,5 +35,8 @@ class DescribeConversionTasks(EC2Request):
     LIST_TAGS = ['conversionTasks', 'volumes']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for task in result.get('conversionTasks') or []:
             self.print_conversion_task(task)

--- a/euca2ools/commands/ec2/describeconversiontasks.py
+++ b/euca2ools/commands/ec2/describeconversiontasks.py
@@ -33,6 +33,6 @@ class DescribeConversionTasks(EC2Request):
                 help='limit results to specific tasks')]
     LIST_TAGS = ['conversionTasks', 'volumes']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for task in result.get('conversionTasks') or []:
             self.print_conversion_task(task)

--- a/euca2ools/commands/ec2/describeconversiontasks.py
+++ b/euca2ools/commands/ec2/describeconversiontasks.py
@@ -26,7 +26,6 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg
 
-import json
 
 class DescribeConversionTasks(EC2Request):
     DESCRIPTION = 'Show information about import operations'
@@ -34,9 +33,6 @@ class DescribeConversionTasks(EC2Request):
                 help='limit results to specific tasks')]
     LIST_TAGS = ['conversionTasks', 'volumes']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for task in result.get('conversionTasks') or []:
             self.print_conversion_task(task)

--- a/euca2ools/commands/ec2/describecustomergateways.py
+++ b/euca2ools/commands/ec2/describecustomergateways.py
@@ -48,6 +48,6 @@ class DescribeCustomerGateways(EC2Request):
 
     LIST_TAGS = ['customerGatewaySet', 'tagSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for cgw in result.get('customerGatewaySet', []):
             self.print_customer_gateway(cgw)

--- a/euca2ools/commands/ec2/describecustomergateways.py
+++ b/euca2ools/commands/ec2/describecustomergateways.py
@@ -27,7 +27,6 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeCustomerGateways(EC2Request):
     DESCRIPTION = 'Show information about VPN customer gateways'
@@ -49,9 +48,6 @@ class DescribeCustomerGateways(EC2Request):
 
     LIST_TAGS = ['customerGatewaySet', 'tagSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for cgw in result.get('customerGatewaySet', []):
             self.print_customer_gateway(cgw)

--- a/euca2ools/commands/ec2/describecustomergateways.py
+++ b/euca2ools/commands/ec2/describecustomergateways.py
@@ -27,6 +27,7 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeCustomerGateways(EC2Request):
     DESCRIPTION = 'Show information about VPN customer gateways'
@@ -49,5 +50,8 @@ class DescribeCustomerGateways(EC2Request):
     LIST_TAGS = ['customerGatewaySet', 'tagSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for cgw in result.get('customerGatewaySet', []):
             self.print_customer_gateway(cgw)

--- a/euca2ools/commands/ec2/describedhcpoptions.py
+++ b/euca2ools/commands/ec2/describedhcpoptions.py
@@ -46,6 +46,6 @@ class DescribeDhcpOptions(EC2Request):
     LIST_TAGS = ['dhcpConfigurationSet', 'dhcpOptionsSet', 'tagSet',
                  'valueSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for dopt in result.get('dhcpOptionsSet', []):
             self.print_dhcp_options(dopt)

--- a/euca2ools/commands/ec2/describedhcpoptions.py
+++ b/euca2ools/commands/ec2/describedhcpoptions.py
@@ -27,7 +27,6 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeDhcpOptions(EC2Request):
     DESCRIPTION = 'Show information about VPC DHCP option sets'
@@ -47,9 +46,6 @@ class DescribeDhcpOptions(EC2Request):
     LIST_TAGS = ['dhcpConfigurationSet', 'dhcpOptionsSet', 'tagSet',
                  'valueSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for dopt in result.get('dhcpOptionsSet', []):
             self.print_dhcp_options(dopt)

--- a/euca2ools/commands/ec2/describedhcpoptions.py
+++ b/euca2ools/commands/ec2/describedhcpoptions.py
@@ -27,6 +27,7 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeDhcpOptions(EC2Request):
     DESCRIPTION = 'Show information about VPC DHCP option sets'
@@ -47,5 +48,8 @@ class DescribeDhcpOptions(EC2Request):
                  'valueSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for dopt in result.get('dhcpOptionsSet', []):
             self.print_dhcp_options(dopt)

--- a/euca2ools/commands/ec2/describeimageattribute.py
+++ b/euca2ools/commands/ec2/describeimageattribute.py
@@ -27,7 +27,6 @@ from requestbuilder import Arg, MutuallyExclusiveArgList
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeImageAttribute(EC2Request):
     DESCRIPTION = 'Show information about an attribute of an image'
@@ -51,10 +50,7 @@ class DescribeImageAttribute(EC2Request):
             .required()]
     LIST_TAGS = ['blockDeviceMapping', 'launchPermission', 'productCodes']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         image_id = result.get('imageId')
         for perm in result.get('launchPermission', []):
             for (entity_type, entity_name) in perm.items():

--- a/euca2ools/commands/ec2/describeimageattribute.py
+++ b/euca2ools/commands/ec2/describeimageattribute.py
@@ -27,6 +27,7 @@ from requestbuilder import Arg, MutuallyExclusiveArgList
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeImageAttribute(EC2Request):
     DESCRIPTION = 'Show information about an attribute of an image'
@@ -51,6 +52,9 @@ class DescribeImageAttribute(EC2Request):
     LIST_TAGS = ['blockDeviceMapping', 'launchPermission', 'productCodes']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         image_id = result.get('imageId')
         for perm in result.get('launchPermission', []):
             for (entity_type, entity_name) in perm.items():

--- a/euca2ools/commands/ec2/describeimageattribute.py
+++ b/euca2ools/commands/ec2/describeimageattribute.py
@@ -50,7 +50,7 @@ class DescribeImageAttribute(EC2Request):
             .required()]
     LIST_TAGS = ['blockDeviceMapping', 'launchPermission', 'productCodes']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         image_id = result.get('imageId')
         for perm in result.get('launchPermission', []):
             for (entity_type, entity_name) in perm.items():

--- a/euca2ools/commands/ec2/describeimages.py
+++ b/euca2ools/commands/ec2/describeimages.py
@@ -29,6 +29,7 @@ import six
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeImages(EC2Request):
     DESCRIPTION = ('Show information about images\n\nBy default, only images '
@@ -123,6 +124,9 @@ class DescribeImages(EC2Request):
             return self.send()
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         images = {}
         for image in result.get('imagesSet', []):
             images.setdefault(image['imageId'], image)

--- a/euca2ools/commands/ec2/describeimages.py
+++ b/euca2ools/commands/ec2/describeimages.py
@@ -29,7 +29,6 @@ import six
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeImages(EC2Request):
     DESCRIPTION = ('Show information about images\n\nBy default, only images '
@@ -123,10 +122,7 @@ class DescribeImages(EC2Request):
         else:
             return self.send()
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         images = {}
         for image in result.get('imagesSet', []):
             images.setdefault(image['imageId'], image)

--- a/euca2ools/commands/ec2/describeimages.py
+++ b/euca2ools/commands/ec2/describeimages.py
@@ -122,7 +122,7 @@ class DescribeImages(EC2Request):
         else:
             return self.send()
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         images = {}
         for image in result.get('imagesSet', []):
             images.setdefault(image['imageId'], image)

--- a/euca2ools/commands/ec2/describeinstanceattribute.py
+++ b/euca2ools/commands/ec2/describeinstanceattribute.py
@@ -29,6 +29,7 @@ from requestbuilder import Arg, MutuallyExclusiveArgList
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeInstanceAttribute(EC2Request):
     DESCRIPTION = ("Show one of an instance's attributes.\n\n"
@@ -79,6 +80,9 @@ class DescribeInstanceAttribute(EC2Request):
     LIST_TAGS = ['blockDeviceMapping', 'groupSet', 'productCodes']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         # Deal with complex data first
         if self.args['Attribute'] == 'blockDeviceMapping':
             for mapping in result.get('blockDeviceMapping', []):

--- a/euca2ools/commands/ec2/describeinstanceattribute.py
+++ b/euca2ools/commands/ec2/describeinstanceattribute.py
@@ -78,7 +78,7 @@ class DescribeInstanceAttribute(EC2Request):
             .required()]
     LIST_TAGS = ['blockDeviceMapping', 'groupSet', 'productCodes']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         # Deal with complex data first
         if self.args['Attribute'] == 'blockDeviceMapping':
             for mapping in result.get('blockDeviceMapping', []):

--- a/euca2ools/commands/ec2/describeinstanceattribute.py
+++ b/euca2ools/commands/ec2/describeinstanceattribute.py
@@ -29,7 +29,6 @@ from requestbuilder import Arg, MutuallyExclusiveArgList
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeInstanceAttribute(EC2Request):
     DESCRIPTION = ("Show one of an instance's attributes.\n\n"
@@ -79,10 +78,7 @@ class DescribeInstanceAttribute(EC2Request):
             .required()]
     LIST_TAGS = ['blockDeviceMapping', 'groupSet', 'productCodes']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         # Deal with complex data first
         if self.args['Attribute'] == 'blockDeviceMapping':
             for mapping in result.get('blockDeviceMapping', []):

--- a/euca2ools/commands/ec2/describeinstances.py
+++ b/euca2ools/commands/ec2/describeinstances.py
@@ -25,6 +25,7 @@
 
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter, GenericTagFilter
+import json
 
 
 class DescribeInstances(EC2Request):
@@ -186,5 +187,8 @@ class DescribeInstances(EC2Request):
                  'privateIpAddressesSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for reservation in result.get('reservationSet'):
             self.print_reservation(reservation)

--- a/euca2ools/commands/ec2/describeinstances.py
+++ b/euca2ools/commands/ec2/describeinstances.py
@@ -25,7 +25,6 @@
 
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter, GenericTagFilter
-import json
 
 
 class DescribeInstances(EC2Request):
@@ -186,9 +185,6 @@ class DescribeInstances(EC2Request):
                  'blockDeviceMapping', 'productCodes', 'networkInterfaceSet',
                  'privateIpAddressesSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for reservation in result.get('reservationSet'):
             self.print_reservation(reservation)

--- a/euca2ools/commands/ec2/describeinstances.py
+++ b/euca2ools/commands/ec2/describeinstances.py
@@ -185,6 +185,6 @@ class DescribeInstances(EC2Request):
                  'blockDeviceMapping', 'productCodes', 'networkInterfaceSet',
                  'privateIpAddressesSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for reservation in result.get('reservationSet'):
             self.print_reservation(reservation)

--- a/euca2ools/commands/ec2/describeinstancestatus.py
+++ b/euca2ools/commands/ec2/describeinstancestatus.py
@@ -29,6 +29,8 @@ from requestbuilder import Arg, Filter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
+
 
 class DescribeInstanceStatus(EC2Request):
     DESCRIPTION = 'Show information about instance status and scheduled events'
@@ -70,6 +72,9 @@ class DescribeInstanceStatus(EC2Request):
     LIST_TAGS = ['instanceStatusSet', 'details', 'eventsSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for sset in result.get('instanceStatusSet') or []:
             if (self.args.get('hide_healthy', False) and
                     sset.get('systemStatus', {}).get('status') == 'ok' and

--- a/euca2ools/commands/ec2/describeinstancestatus.py
+++ b/euca2ools/commands/ec2/describeinstancestatus.py
@@ -29,8 +29,6 @@ from requestbuilder import Arg, Filter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
-
 
 class DescribeInstanceStatus(EC2Request):
     DESCRIPTION = 'Show information about instance status and scheduled events'
@@ -71,10 +69,7 @@ class DescribeInstanceStatus(EC2Request):
                       help="instance's system reachability status")]
     LIST_TAGS = ['instanceStatusSet', 'details', 'eventsSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for sset in result.get('instanceStatusSet') or []:
             if (self.args.get('hide_healthy', False) and
                     sset.get('systemStatus', {}).get('status') == 'ok' and

--- a/euca2ools/commands/ec2/describeinstancestatus.py
+++ b/euca2ools/commands/ec2/describeinstancestatus.py
@@ -69,7 +69,7 @@ class DescribeInstanceStatus(EC2Request):
                       help="instance's system reachability status")]
     LIST_TAGS = ['instanceStatusSet', 'details', 'eventsSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for sset in result.get('instanceStatusSet') or []:
             if (self.args.get('hide_healthy', False) and
                     sset.get('systemStatus', {}).get('status') == 'ok' and

--- a/euca2ools/commands/ec2/describeinstancetypes.py
+++ b/euca2ools/commands/ec2/describeinstancetypes.py
@@ -28,8 +28,6 @@ from requestbuilder.mixins import TabifyingMixin
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
-
 
 class DescribeInstanceTypes(EC2Request, TabifyingMixin):
     DESCRIPTION = '[Eucalyptus only] Show information about instance types'
@@ -47,10 +45,7 @@ class DescribeInstanceTypes(EC2Request, TabifyingMixin):
         if self.args.get('by_zone', False):
             self.params['Availability'] = True
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         vmtype_names = []  # Use a list since py2.6 lacks OrderedDict
         vmtypes = {}  # vmtype -> info and total capacity
         zones = {}  # zone -> vmtype -> info and zone capacity

--- a/euca2ools/commands/ec2/describeinstancetypes.py
+++ b/euca2ools/commands/ec2/describeinstancetypes.py
@@ -28,6 +28,8 @@ from requestbuilder.mixins import TabifyingMixin
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
+
 
 class DescribeInstanceTypes(EC2Request, TabifyingMixin):
     DESCRIPTION = '[Eucalyptus only] Show information about instance types'
@@ -46,6 +48,9 @@ class DescribeInstanceTypes(EC2Request, TabifyingMixin):
             self.params['Availability'] = True
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         vmtype_names = []  # Use a list since py2.6 lacks OrderedDict
         vmtypes = {}  # vmtype -> info and total capacity
         zones = {}  # zone -> vmtype -> info and zone capacity

--- a/euca2ools/commands/ec2/describeinstancetypes.py
+++ b/euca2ools/commands/ec2/describeinstancetypes.py
@@ -45,7 +45,7 @@ class DescribeInstanceTypes(EC2Request, TabifyingMixin):
         if self.args.get('by_zone', False):
             self.params['Availability'] = True
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         vmtype_names = []  # Use a list since py2.6 lacks OrderedDict
         vmtypes = {}  # vmtype -> info and total capacity
         zones = {}  # zone -> vmtype -> info and zone capacity

--- a/euca2ools/commands/ec2/describeinternetgateways.py
+++ b/euca2ools/commands/ec2/describeinternetgateways.py
@@ -46,6 +46,6 @@ class DescribeInternetGateways(EC2Request):
 
     LIST_TAGS = ['attachmentSet', 'internetGatewaySet', 'tagSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for igw in result.get('internetGatewaySet') or []:
             self.print_internet_gateway(igw)

--- a/euca2ools/commands/ec2/describeinternetgateways.py
+++ b/euca2ools/commands/ec2/describeinternetgateways.py
@@ -27,8 +27,6 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
-
 
 class DescribeInternetGateways(EC2Request):
     DESCRIPTION = 'Describe one or more VPC Internet gateways'
@@ -48,9 +46,6 @@ class DescribeInternetGateways(EC2Request):
 
     LIST_TAGS = ['attachmentSet', 'internetGatewaySet', 'tagSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for igw in result.get('internetGatewaySet') or []:
             self.print_internet_gateway(igw)

--- a/euca2ools/commands/ec2/describeinternetgateways.py
+++ b/euca2ools/commands/ec2/describeinternetgateways.py
@@ -27,6 +27,8 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
+
 
 class DescribeInternetGateways(EC2Request):
     DESCRIPTION = 'Describe one or more VPC Internet gateways'
@@ -47,5 +49,8 @@ class DescribeInternetGateways(EC2Request):
     LIST_TAGS = ['attachmentSet', 'internetGatewaySet', 'tagSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for igw in result.get('internetGatewaySet') or []:
             self.print_internet_gateway(igw)

--- a/euca2ools/commands/ec2/describekeypairs.py
+++ b/euca2ools/commands/ec2/describekeypairs.py
@@ -35,7 +35,7 @@ class DescribeKeyPairs(EC2Request):
                Filter('key-name', help='name of the key pair')]
     LIST_TAGS = ['keySet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for key in result.get('keySet', []):
             print self.tabify(('KEYPAIR', key.get('keyName'),
                                key.get('keyFingerprint')))

--- a/euca2ools/commands/ec2/describekeypairs.py
+++ b/euca2ools/commands/ec2/describekeypairs.py
@@ -26,7 +26,6 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter
 
-import json
 
 class DescribeKeyPairs(EC2Request):
     DESCRIPTION = 'Display information about available key pairs'
@@ -36,10 +35,7 @@ class DescribeKeyPairs(EC2Request):
                Filter('key-name', help='name of the key pair')]
     LIST_TAGS = ['keySet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for key in result.get('keySet', []):
             print self.tabify(('KEYPAIR', key.get('keyName'),
                                key.get('keyFingerprint')))

--- a/euca2ools/commands/ec2/describekeypairs.py
+++ b/euca2ools/commands/ec2/describekeypairs.py
@@ -26,6 +26,7 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter
 
+import json
 
 class DescribeKeyPairs(EC2Request):
     DESCRIPTION = 'Display information about available key pairs'
@@ -36,6 +37,9 @@ class DescribeKeyPairs(EC2Request):
     LIST_TAGS = ['keySet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for key in result.get('keySet', []):
             print self.tabify(('KEYPAIR', key.get('keyName'),
                                key.get('keyFingerprint')))

--- a/euca2ools/commands/ec2/describenetworkacls.py
+++ b/euca2ools/commands/ec2/describenetworkacls.py
@@ -68,6 +68,6 @@ class DescribeNetworkAcls(EC2Request):
 
     LIST_TAGS = ['associationSet', 'entrySet', 'networkAclSet', 'tagSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for acl in result.get('networkAclSet') or []:
             self.print_network_acl(acl)

--- a/euca2ools/commands/ec2/describenetworkacls.py
+++ b/euca2ools/commands/ec2/describenetworkacls.py
@@ -27,6 +27,7 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeNetworkAcls(EC2Request):
     DESCRIPTION = 'Describe one or more network ACLs'
@@ -69,5 +70,8 @@ class DescribeNetworkAcls(EC2Request):
     LIST_TAGS = ['associationSet', 'entrySet', 'networkAclSet', 'tagSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for acl in result.get('networkAclSet') or []:
             self.print_network_acl(acl)

--- a/euca2ools/commands/ec2/describenetworkacls.py
+++ b/euca2ools/commands/ec2/describenetworkacls.py
@@ -27,7 +27,6 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeNetworkAcls(EC2Request):
     DESCRIPTION = 'Describe one or more network ACLs'
@@ -69,9 +68,6 @@ class DescribeNetworkAcls(EC2Request):
 
     LIST_TAGS = ['associationSet', 'entrySet', 'networkAclSet', 'tagSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for acl in result.get('networkAclSet') or []:
             self.print_network_acl(acl)

--- a/euca2ools/commands/ec2/describenetworkinterfaceattribute.py
+++ b/euca2ools/commands/ec2/describenetworkinterfaceattribute.py
@@ -51,9 +51,6 @@ class DescribeNetworkInterfaceAttribute(EC2Request):
     LIST_TAGS = ['groupSet']
 
     def print_result_plain(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
         print self.tabify(('NETWORKINTERFACE',
                            result.get('networkInterfaceId'),
                            self.args['Attribute']))

--- a/euca2ools/commands/ec2/describenetworkinterfaceattribute.py
+++ b/euca2ools/commands/ec2/describenetworkinterfaceattribute.py
@@ -50,7 +50,7 @@ class DescribeNetworkInterfaceAttribute(EC2Request):
 
     LIST_TAGS = ['groupSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         if self.args['json']:
             print json.dumps(result, sort_keys=True, indent=2)
             return

--- a/euca2ools/commands/ec2/describenetworkinterfaceattribute.py
+++ b/euca2ools/commands/ec2/describenetworkinterfaceattribute.py
@@ -27,7 +27,6 @@ from requestbuilder import Arg, MutuallyExclusiveArgList
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeNetworkInterfaceAttribute(EC2Request):
     DESCRIPTION = 'Show an attribute of a VPC network interface'
@@ -51,7 +50,7 @@ class DescribeNetworkInterfaceAttribute(EC2Request):
 
     LIST_TAGS = ['groupSet']
 
-    def print_result(self, result):
+    def print_result_native(self, result):
         if self.args['json']:
             print json.dumps(result, sort_keys=True, indent=2)
             return

--- a/euca2ools/commands/ec2/describenetworkinterfaceattribute.py
+++ b/euca2ools/commands/ec2/describenetworkinterfaceattribute.py
@@ -27,6 +27,7 @@ from requestbuilder import Arg, MutuallyExclusiveArgList
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeNetworkInterfaceAttribute(EC2Request):
     DESCRIPTION = 'Show an attribute of a VPC network interface'
@@ -51,6 +52,9 @@ class DescribeNetworkInterfaceAttribute(EC2Request):
     LIST_TAGS = ['groupSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         print self.tabify(('NETWORKINTERFACE',
                            result.get('networkInterfaceId'),
                            self.args['Attribute']))

--- a/euca2ools/commands/ec2/describenetworkinterfaces.py
+++ b/euca2ools/commands/ec2/describenetworkinterfaces.py
@@ -27,7 +27,6 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeNetworkInterfaces(EC2Request):
     DESCRIPTION = 'Show information about VPC network interfaces'
@@ -107,9 +106,6 @@ class DescribeNetworkInterfaces(EC2Request):
     LIST_TAGS = ['groupSet', 'networkInterfaceSet', 'privateIpAddressesSet',
                  'tagSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for nic in result.get('networkInterfaceSet') or []:
             self.print_interface(nic)

--- a/euca2ools/commands/ec2/describenetworkinterfaces.py
+++ b/euca2ools/commands/ec2/describenetworkinterfaces.py
@@ -27,6 +27,7 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeNetworkInterfaces(EC2Request):
     DESCRIPTION = 'Show information about VPC network interfaces'
@@ -107,5 +108,8 @@ class DescribeNetworkInterfaces(EC2Request):
                  'tagSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for nic in result.get('networkInterfaceSet') or []:
             self.print_interface(nic)

--- a/euca2ools/commands/ec2/describenetworkinterfaces.py
+++ b/euca2ools/commands/ec2/describenetworkinterfaces.py
@@ -106,6 +106,6 @@ class DescribeNetworkInterfaces(EC2Request):
     LIST_TAGS = ['groupSet', 'networkInterfaceSet', 'privateIpAddressesSet',
                  'tagSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for nic in result.get('networkInterfaceSet') or []:
             self.print_interface(nic)

--- a/euca2ools/commands/ec2/describeregions.py
+++ b/euca2ools/commands/ec2/describeregions.py
@@ -26,7 +26,6 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter
 
-import json
 
 class DescribeRegions(EC2Request):
     DESCRIPTION = 'Display information about regions'
@@ -36,10 +35,7 @@ class DescribeRegions(EC2Request):
                Filter('region-name')]
     LIST_TAGS = ['regionInfo']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for region in result.get('regionInfo', []):
             print self.tabify(('REGION', region.get('regionName'),
                                region.get('regionEndpoint')))

--- a/euca2ools/commands/ec2/describeregions.py
+++ b/euca2ools/commands/ec2/describeregions.py
@@ -26,6 +26,7 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter
 
+import json
 
 class DescribeRegions(EC2Request):
     DESCRIPTION = 'Display information about regions'
@@ -36,6 +37,9 @@ class DescribeRegions(EC2Request):
     LIST_TAGS = ['regionInfo']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for region in result.get('regionInfo', []):
             print self.tabify(('REGION', region.get('regionName'),
                                region.get('regionEndpoint')))

--- a/euca2ools/commands/ec2/describeregions.py
+++ b/euca2ools/commands/ec2/describeregions.py
@@ -35,7 +35,7 @@ class DescribeRegions(EC2Request):
                Filter('region-name')]
     LIST_TAGS = ['regionInfo']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for region in result.get('regionInfo', []):
             print self.tabify(('REGION', region.get('regionName'),
                                region.get('regionEndpoint')))

--- a/euca2ools/commands/ec2/describeroutetables.py
+++ b/euca2ools/commands/ec2/describeroutetables.py
@@ -68,6 +68,6 @@ class DescribeRouteTables(EC2Request):
     LIST_TAGS = ['associationSet', 'propagatingVgwSet', 'routeTableSet',
                  'routeSet', 'tagSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for table in result.get('routeTableSet') or []:
             self.print_route_table(table)

--- a/euca2ools/commands/ec2/describeroutetables.py
+++ b/euca2ools/commands/ec2/describeroutetables.py
@@ -27,7 +27,6 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeRouteTables(EC2Request):
     DESCRIPTION = 'Describe one or more VPC route tables'
@@ -69,9 +68,6 @@ class DescribeRouteTables(EC2Request):
     LIST_TAGS = ['associationSet', 'propagatingVgwSet', 'routeTableSet',
                  'routeSet', 'tagSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for table in result.get('routeTableSet') or []:
             self.print_route_table(table)

--- a/euca2ools/commands/ec2/describeroutetables.py
+++ b/euca2ools/commands/ec2/describeroutetables.py
@@ -27,6 +27,7 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeRouteTables(EC2Request):
     DESCRIPTION = 'Describe one or more VPC route tables'
@@ -69,5 +70,8 @@ class DescribeRouteTables(EC2Request):
                  'routeSet', 'tagSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for table in result.get('routeTableSet') or []:
             self.print_route_table(table)

--- a/euca2ools/commands/ec2/describesecuritygroups.py
+++ b/euca2ools/commands/ec2/describesecuritygroups.py
@@ -71,7 +71,7 @@ class DescribeSecurityGroups(EC2Request):
                 self.params.setdefault('GroupName', [])
                 self.params['GroupName'].append(group)
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for group in result.get('securityGroupInfo', []):
             self.print_group(group)
 

--- a/euca2ools/commands/ec2/describesecuritygroups.py
+++ b/euca2ools/commands/ec2/describesecuritygroups.py
@@ -26,7 +26,6 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter, GenericTagFilter
 
-import json
 
 class DescribeSecurityGroups(EC2Request):
     DESCRIPTION = ('Show information about security groups\n\nNote that '
@@ -72,10 +71,7 @@ class DescribeSecurityGroups(EC2Request):
                 self.params.setdefault('GroupName', [])
                 self.params['GroupName'].append(group)
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for group in result.get('securityGroupInfo', []):
             self.print_group(group)
 

--- a/euca2ools/commands/ec2/describesecuritygroups.py
+++ b/euca2ools/commands/ec2/describesecuritygroups.py
@@ -26,6 +26,7 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter, GenericTagFilter
 
+import json
 
 class DescribeSecurityGroups(EC2Request):
     DESCRIPTION = ('Show information about security groups\n\nNote that '
@@ -72,6 +73,9 @@ class DescribeSecurityGroups(EC2Request):
                 self.params['GroupName'].append(group)
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for group in result.get('securityGroupInfo', []):
             self.print_group(group)
 

--- a/euca2ools/commands/ec2/describesnapshotattribute.py
+++ b/euca2ools/commands/ec2/describesnapshotattribute.py
@@ -41,7 +41,7 @@ class DescribeSnapshotAttribute(EC2Request):
             .required()]
     LIST_TAGS = ['createVolumePermission', 'productCodes']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         snapshot_id = result.get('snapshotId')
         for perm in result.get('createVolumePermission', []):
             for (entity_type, entity_name) in perm.items():

--- a/euca2ools/commands/ec2/describesnapshotattribute.py
+++ b/euca2ools/commands/ec2/describesnapshotattribute.py
@@ -27,6 +27,7 @@ from requestbuilder import Arg, MutuallyExclusiveArgList
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeSnapshotAttribute(EC2Request):
     DESCRIPTION = 'Show information about an attribute of a snapshot'
@@ -42,6 +43,9 @@ class DescribeSnapshotAttribute(EC2Request):
     LIST_TAGS = ['createVolumePermission', 'productCodes']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         snapshot_id = result.get('snapshotId')
         for perm in result.get('createVolumePermission', []):
             for (entity_type, entity_name) in perm.items():

--- a/euca2ools/commands/ec2/describesnapshotattribute.py
+++ b/euca2ools/commands/ec2/describesnapshotattribute.py
@@ -27,7 +27,6 @@ from requestbuilder import Arg, MutuallyExclusiveArgList
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeSnapshotAttribute(EC2Request):
     DESCRIPTION = 'Show information about an attribute of a snapshot'
@@ -42,10 +41,7 @@ class DescribeSnapshotAttribute(EC2Request):
             .required()]
     LIST_TAGS = ['createVolumePermission', 'productCodes']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         snapshot_id = result.get('snapshotId')
         for perm in result.get('createVolumePermission', []):
             for (entity_type, entity_name) in perm.items():

--- a/euca2ools/commands/ec2/describesnapshots.py
+++ b/euca2ools/commands/ec2/describesnapshots.py
@@ -27,7 +27,6 @@ from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter, GenericTagFilter
 from requestbuilder.exceptions import ArgumentError
 
-import json
 
 class DescribeSnapshots(EC2Request):
     DESCRIPTION = ('Show information about snapshots\n\nBy default, only '
@@ -86,9 +85,6 @@ class DescribeSnapshots(EC2Request):
         else:
             return self.send()
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for snapshot in result.get('snapshotSet', []):
             self.print_snapshot(snapshot)

--- a/euca2ools/commands/ec2/describesnapshots.py
+++ b/euca2ools/commands/ec2/describesnapshots.py
@@ -27,6 +27,7 @@ from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter, GenericTagFilter
 from requestbuilder.exceptions import ArgumentError
 
+import json
 
 class DescribeSnapshots(EC2Request):
     DESCRIPTION = ('Show information about snapshots\n\nBy default, only '
@@ -86,5 +87,8 @@ class DescribeSnapshots(EC2Request):
             return self.send()
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for snapshot in result.get('snapshotSet', []):
             self.print_snapshot(snapshot)

--- a/euca2ools/commands/ec2/describesnapshots.py
+++ b/euca2ools/commands/ec2/describesnapshots.py
@@ -85,6 +85,6 @@ class DescribeSnapshots(EC2Request):
         else:
             return self.send()
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for snapshot in result.get('snapshotSet', []):
             self.print_snapshot(snapshot)

--- a/euca2ools/commands/ec2/describesubnets.py
+++ b/euca2ools/commands/ec2/describesubnets.py
@@ -29,7 +29,6 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeSubnets(EC2Request):
     DESCRIPTION = 'Show information about one or more VPC subnets'
@@ -55,9 +54,6 @@ class DescribeSubnets(EC2Request):
                Filter('vpc-id', help="the associated VPC's ID")]
     LIST_TAGS = ['subnetSet', 'tagSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for subnet in result.get('subnetSet') or []:
             self.print_subnet(subnet)

--- a/euca2ools/commands/ec2/describesubnets.py
+++ b/euca2ools/commands/ec2/describesubnets.py
@@ -54,6 +54,6 @@ class DescribeSubnets(EC2Request):
                Filter('vpc-id', help="the associated VPC's ID")]
     LIST_TAGS = ['subnetSet', 'tagSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for subnet in result.get('subnetSet') or []:
             self.print_subnet(subnet)

--- a/euca2ools/commands/ec2/describesubnets.py
+++ b/euca2ools/commands/ec2/describesubnets.py
@@ -29,6 +29,7 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeSubnets(EC2Request):
     DESCRIPTION = 'Show information about one or more VPC subnets'
@@ -55,5 +56,8 @@ class DescribeSubnets(EC2Request):
     LIST_TAGS = ['subnetSet', 'tagSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for subnet in result.get('subnetSet') or []:
             self.print_subnet(subnet)

--- a/euca2ools/commands/ec2/describetags.py
+++ b/euca2ools/commands/ec2/describetags.py
@@ -27,7 +27,6 @@ from requestbuilder import Filter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeTags(EC2Request):
     DESCRIPTION = "List tags associated with your account's resources"
@@ -37,10 +36,7 @@ class DescribeTags(EC2Request):
                Filter('value')]
     LIST_TAGS = ['tagSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for tag in result.get('tagSet', []):
             print self.tabify(['TAG', tag.get('resourceType'),
                                tag.get('resourceId'), tag.get('key'),

--- a/euca2ools/commands/ec2/describetags.py
+++ b/euca2ools/commands/ec2/describetags.py
@@ -36,7 +36,7 @@ class DescribeTags(EC2Request):
                Filter('value')]
     LIST_TAGS = ['tagSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for tag in result.get('tagSet', []):
             print self.tabify(['TAG', tag.get('resourceType'),
                                tag.get('resourceId'), tag.get('key'),

--- a/euca2ools/commands/ec2/describetags.py
+++ b/euca2ools/commands/ec2/describetags.py
@@ -27,6 +27,7 @@ from requestbuilder import Filter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeTags(EC2Request):
     DESCRIPTION = "List tags associated with your account's resources"
@@ -37,6 +38,9 @@ class DescribeTags(EC2Request):
     LIST_TAGS = ['tagSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for tag in result.get('tagSet', []):
             print self.tabify(['TAG', tag.get('resourceType'),
                                tag.get('resourceId'), tag.get('key'),

--- a/euca2ools/commands/ec2/describevolumes.py
+++ b/euca2ools/commands/ec2/describevolumes.py
@@ -54,6 +54,6 @@ class DescribeVolumes(EC2Request):
                Filter(name='volume-type')]
     LIST_TAGS = ['volumeSet', 'attachmentSet', 'tagSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for volume in result.get('volumeSet'):
             self.print_volume(volume)

--- a/euca2ools/commands/ec2/describevolumes.py
+++ b/euca2ools/commands/ec2/describevolumes.py
@@ -26,6 +26,7 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter, GenericTagFilter
 
+import json
 
 class DescribeVolumes(EC2Request):
     DESCRIPTION = 'Display information about volumes'
@@ -55,5 +56,8 @@ class DescribeVolumes(EC2Request):
     LIST_TAGS = ['volumeSet', 'attachmentSet', 'tagSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for volume in result.get('volumeSet'):
             self.print_volume(volume)

--- a/euca2ools/commands/ec2/describevolumes.py
+++ b/euca2ools/commands/ec2/describevolumes.py
@@ -26,7 +26,6 @@
 from euca2ools.commands.ec2 import EC2Request
 from requestbuilder import Arg, Filter, GenericTagFilter
 
-import json
 
 class DescribeVolumes(EC2Request):
     DESCRIPTION = 'Display information about volumes'
@@ -55,9 +54,6 @@ class DescribeVolumes(EC2Request):
                Filter(name='volume-type')]
     LIST_TAGS = ['volumeSet', 'attachmentSet', 'tagSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for volume in result.get('volumeSet'):
             self.print_volume(volume)

--- a/euca2ools/commands/ec2/describevpcattribute.py
+++ b/euca2ools/commands/ec2/describevpcattribute.py
@@ -27,8 +27,6 @@ from requestbuilder import Arg, MutuallyExclusiveArgList
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
-
 
 class DescribeVpcAttribute(EC2Request):
     DESCRIPTION = 'Show an attribute of a VPC'
@@ -44,10 +42,7 @@ class DescribeVpcAttribute(EC2Request):
                     help='show whether DNS resolution is enabled'))
             .required()]
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         if self.args['Attribute'] == 'enableDnsHostnames':
             print self.tabify(('RETURN',
                                result['enableDnsHostnames'].get('value')))

--- a/euca2ools/commands/ec2/describevpcattribute.py
+++ b/euca2ools/commands/ec2/describevpcattribute.py
@@ -27,6 +27,8 @@ from requestbuilder import Arg, MutuallyExclusiveArgList
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
+
 
 class DescribeVpcAttribute(EC2Request):
     DESCRIPTION = 'Show an attribute of a VPC'
@@ -43,6 +45,9 @@ class DescribeVpcAttribute(EC2Request):
             .required()]
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         if self.args['Attribute'] == 'enableDnsHostnames':
             print self.tabify(('RETURN',
                                result['enableDnsHostnames'].get('value')))

--- a/euca2ools/commands/ec2/describevpcattribute.py
+++ b/euca2ools/commands/ec2/describevpcattribute.py
@@ -42,7 +42,7 @@ class DescribeVpcAttribute(EC2Request):
                     help='show whether DNS resolution is enabled'))
             .required()]
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         if self.args['Attribute'] == 'enableDnsHostnames':
             print self.tabify(('RETURN',
                                result['enableDnsHostnames'].get('value')))

--- a/euca2ools/commands/ec2/describevpcpeeringconnections.py
+++ b/euca2ools/commands/ec2/describevpcpeeringconnections.py
@@ -27,6 +27,7 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeVpcPeeringConnections(EC2Request):
     DESCRIPTION = 'Show information about VPC peering connections'
@@ -59,5 +60,8 @@ class DescribeVpcPeeringConnections(EC2Request):
     LIST_TAGS = ['tagSet', 'vpcPeeringConnectionSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for pcx in result.get('vpcPeeringConnectionSet') or []:
             self.print_peering_connection(pcx)

--- a/euca2ools/commands/ec2/describevpcpeeringconnections.py
+++ b/euca2ools/commands/ec2/describevpcpeeringconnections.py
@@ -58,6 +58,6 @@ class DescribeVpcPeeringConnections(EC2Request):
                       help="the peering connection's ID")]
     LIST_TAGS = ['tagSet', 'vpcPeeringConnectionSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for pcx in result.get('vpcPeeringConnectionSet') or []:
             self.print_peering_connection(pcx)

--- a/euca2ools/commands/ec2/describevpcpeeringconnections.py
+++ b/euca2ools/commands/ec2/describevpcpeeringconnections.py
@@ -27,7 +27,6 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeVpcPeeringConnections(EC2Request):
     DESCRIPTION = 'Show information about VPC peering connections'
@@ -59,9 +58,6 @@ class DescribeVpcPeeringConnections(EC2Request):
                       help="the peering connection's ID")]
     LIST_TAGS = ['tagSet', 'vpcPeeringConnectionSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for pcx in result.get('vpcPeeringConnectionSet') or []:
             self.print_peering_connection(pcx)

--- a/euca2ools/commands/ec2/describevpcs.py
+++ b/euca2ools/commands/ec2/describevpcs.py
@@ -27,6 +27,7 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
 
 class DescribeVpcs(EC2Request):
     DESCRIPTION = 'Show information about VPCs'
@@ -44,5 +45,8 @@ class DescribeVpcs(EC2Request):
     LIST_TAGS = ['tagSet', 'vpcSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for vpc in result.get('vpcSet') or []:
             self.print_vpc(vpc)

--- a/euca2ools/commands/ec2/describevpcs.py
+++ b/euca2ools/commands/ec2/describevpcs.py
@@ -43,6 +43,6 @@ class DescribeVpcs(EC2Request):
                Filter('vpc-id', help="the VPC's ID")]
     LIST_TAGS = ['tagSet', 'vpcSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for vpc in result.get('vpcSet') or []:
             self.print_vpc(vpc)

--- a/euca2ools/commands/ec2/describevpcs.py
+++ b/euca2ools/commands/ec2/describevpcs.py
@@ -27,7 +27,6 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
 
 class DescribeVpcs(EC2Request):
     DESCRIPTION = 'Show information about VPCs'
@@ -44,9 +43,6 @@ class DescribeVpcs(EC2Request):
                Filter('vpc-id', help="the VPC's ID")]
     LIST_TAGS = ['tagSet', 'vpcSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for vpc in result.get('vpcSet') or []:
             self.print_vpc(vpc)

--- a/euca2ools/commands/ec2/describevpnconnections.py
+++ b/euca2ools/commands/ec2/describevpnconnections.py
@@ -72,7 +72,7 @@ class DescribeVpnConnections(EC2Request):
                       help='ID of the connected virtual private gateway')]
     LIST_TAGS = ['vpnConnectionSet', 'tagSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         if self.args.get('format') is None:
             stylesheet = self.args.get('stylesheet')
             show_conn_info = bool(stylesheet)

--- a/euca2ools/commands/ec2/describevpnconnections.py
+++ b/euca2ools/commands/ec2/describevpnconnections.py
@@ -30,8 +30,6 @@ import six
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
-
 
 class DescribeVpnConnections(EC2Request):
     DESCRIPTION = 'Show information about VPN connections'
@@ -74,10 +72,7 @@ class DescribeVpnConnections(EC2Request):
                       help='ID of the connected virtual private gateway')]
     LIST_TAGS = ['vpnConnectionSet', 'tagSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         if self.args.get('format') is None:
             stylesheet = self.args.get('stylesheet')
             show_conn_info = bool(stylesheet)

--- a/euca2ools/commands/ec2/describevpnconnections.py
+++ b/euca2ools/commands/ec2/describevpnconnections.py
@@ -30,6 +30,8 @@ import six
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
+
 
 class DescribeVpnConnections(EC2Request):
     DESCRIPTION = 'Show information about VPN connections'
@@ -73,6 +75,9 @@ class DescribeVpnConnections(EC2Request):
     LIST_TAGS = ['vpnConnectionSet', 'tagSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         if self.args.get('format') is None:
             stylesheet = self.args.get('stylesheet')
             show_conn_info = bool(stylesheet)

--- a/euca2ools/commands/ec2/describevpngateways.py
+++ b/euca2ools/commands/ec2/describevpngateways.py
@@ -51,6 +51,6 @@ class DescribeVpnGateways(EC2Request):
 
     LIST_TAGS = ['attachments', 'vpnGatewaySet', 'tagSet']
 
-    def print_result_native(self, result):
+    def print_result_plain(self, result):
         for vgw in result.get('vpnGatewaySet', []):
             self.print_vpn_gateway(vgw)

--- a/euca2ools/commands/ec2/describevpngateways.py
+++ b/euca2ools/commands/ec2/describevpngateways.py
@@ -27,6 +27,8 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
+import json
+
 
 class DescribeVpnGateways(EC2Request):
     DESCRIPTION = 'Show information about virtual private gateways'
@@ -52,5 +54,8 @@ class DescribeVpnGateways(EC2Request):
     LIST_TAGS = ['attachments', 'vpnGatewaySet', 'tagSet']
 
     def print_result(self, result):
+        if self.args['json']:
+            print json.dumps(result, sort_keys=True, indent=2)
+            return
         for vgw in result.get('vpnGatewaySet', []):
             self.print_vpn_gateway(vgw)

--- a/euca2ools/commands/ec2/describevpngateways.py
+++ b/euca2ools/commands/ec2/describevpngateways.py
@@ -27,8 +27,6 @@ from requestbuilder import Arg, Filter, GenericTagFilter
 
 from euca2ools.commands.ec2 import EC2Request
 
-import json
-
 
 class DescribeVpnGateways(EC2Request):
     DESCRIPTION = 'Show information about virtual private gateways'
@@ -53,9 +51,6 @@ class DescribeVpnGateways(EC2Request):
 
     LIST_TAGS = ['attachments', 'vpnGatewaySet', 'tagSet']
 
-    def print_result(self, result):
-        if self.args['json']:
-            print json.dumps(result, sort_keys=True, indent=2)
-            return
+    def print_result_native(self, result):
         for vgw in result.get('vpnGatewaySet', []):
             self.print_vpn_gateway(vgw)

--- a/man/euca-describe-account-attributes.1
+++ b/man/euca-describe-account-attributes.1
@@ -18,6 +18,9 @@ ATTRIBUTE
 limit results to specific account attributes
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-addresses.1
+++ b/man/euca-describe-addresses.1
@@ -18,6 +18,9 @@ limit results to specific elastic IP addresses or VPC
 allocation IDs
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-availability-zones.1
+++ b/man/euca-describe-availability-zones.1
@@ -18,6 +18,9 @@ ZONE
 limit results to specific availability zones
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-bundle-tasks.1
+++ b/man/euca-describe-bundle-tasks.1
@@ -18,6 +18,9 @@ BUNDLE
 limit results to specific bundle tasks
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-conversion-tasks.1
+++ b/man/euca-describe-conversion-tasks.1
@@ -17,6 +17,9 @@ TASK
 limit results to specific tasks
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-customer-gateways.1
+++ b/man/euca-describe-customer-gateways.1
@@ -18,6 +18,9 @@ CGATEWAY
 limit results to specific customer gateways
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-dhcp-options.1
+++ b/man/euca-describe-dhcp-options.1
@@ -18,6 +18,9 @@ DHCPOPTS
 limit results to specific DHCP option sets
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-image-attribute.1
+++ b/man/euca-describe-image-attribute.1
@@ -37,6 +37,9 @@ show associated ramdisk image ID
 \fB\-\-description\fR
 show the image's description
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-images.1
+++ b/man/euca-describe-images.1
@@ -31,6 +31,9 @@ describe images owned by the specified owner
 describe images for which the specified account has
 explicit launch permissions
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-instance-attribute.1
+++ b/man/euca-describe-instance-attribute.1
@@ -63,6 +63,9 @@ enabled for the instance
 \fB\-\-user\-data\fR
 show the instance's user\-data
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-instance-status.1
+++ b/man/euca-describe-instance-status.1
@@ -26,6 +26,9 @@ hide instances where all status checks pass
 \fB\-\-include\-all\-instances\fR
 show all instances, not just those that are running
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-instance-types.1
+++ b/man/euca-describe-instance-types.1
@@ -24,6 +24,9 @@ show info for each availability zone separately
 \fB\-\-show\-capacity\fR
 show info about instance capacity
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-instances.1
+++ b/man/euca-describe-instances.1
@@ -17,6 +17,9 @@ INSTANCE
 limit results to specific instances
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-internet-gateways.1
+++ b/man/euca-describe-internet-gateways.1
@@ -18,6 +18,9 @@ IGATEWAY
 limit results to one or more Internet gateways
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-keypairs.1
+++ b/man/euca-describe-keypairs.1
@@ -17,6 +17,9 @@ KEYPAIR
 limit results to specific key pairs
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-network-acls.1
+++ b/man/euca-describe-network-acls.1
@@ -18,6 +18,9 @@ NACL
 limit results to one or more network ACLs
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-network-interface-attribute.1
+++ b/man/euca-describe-network-interface-attribute.1
@@ -36,6 +36,9 @@ to
 \fB\-a\fR, \fB\-\-attachment\fR
 show info about the interface's attachment (if any)
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-network-interfaces.1
+++ b/man/euca-describe-network-interfaces.1
@@ -18,6 +18,9 @@ INTERFACE
 limit results to specific network interfaces
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-regions.1
+++ b/man/euca-describe-regions.1
@@ -17,6 +17,9 @@ REGION
 limit results to specific regions
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-route-tables.1
+++ b/man/euca-describe-route-tables.1
@@ -18,6 +18,9 @@ RTABLE
 limit results to specific route tables
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-snapshot-attribute.1
+++ b/man/euca-describe-snapshot-attribute.1
@@ -24,6 +24,9 @@ display who can create volumes from the snapshot
 \fB\-p\fR, \fB\-\-product\-codes\fR
 list associated product codes
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-snapshots.1
+++ b/man/euca-describe-snapshots.1
@@ -31,6 +31,9 @@ limit results to snapshots owned by specific accounts
 limit results to snapahots restorable by specific
 accounts
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-subnets.1
+++ b/man/euca-describe-subnets.1
@@ -17,6 +17,9 @@ SUBNET
 limit results to specific subnets
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-tags.1
+++ b/man/euca-describe-tags.1
@@ -12,6 +12,9 @@ euca\-describe\-tags [\-\-show\-empty\-fields] [\-U URL]
 List tags associated with your account's resources
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-volumes.1
+++ b/man/euca-describe-volumes.1
@@ -17,6 +17,9 @@ VOLUME
 limit results to specific volumes
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-vpc-attribute.1
+++ b/man/euca-describe-vpc-attribute.1
@@ -24,6 +24,9 @@ hostnames
 \fB\-s\fR, \fB\-\-dns\-support\fR
 show whether DNS resolution is enabled
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-vpc-peering-connections.1
+++ b/man/euca-describe-vpc-peering-connections.1
@@ -19,6 +19,9 @@ PEERCONN
 limit results to specific VPC peering connections
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-vpcs.1
+++ b/man/euca-describe-vpcs.1
@@ -17,6 +17,9 @@ VPC
 limit results to specific VPCs
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-vpn-connections.1
+++ b/man/euca-describe-vpn-connections.1
@@ -33,6 +33,9 @@ be replaced with the format chosen by the \fB\-\-format\fR
 option. If the value is an HTTP or HTTPS URL it will
 be downloaded as needed. (default: value of "vpnstylesheet" region option)
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP

--- a/man/euca-describe-vpn-gateways.1
+++ b/man/euca-describe-vpn-gateways.1
@@ -18,6 +18,9 @@ VGATEWAY
 limit results to specific virtual private gateways
 .SS "optional arguments:"
 .TP
+\fB\-\-pretty\fR json
+Pretty print output format
+.TP
 \fB\-\-show\-empty\-fields\fR
 show empty values as "(nil)"
 .TP


### PR DESCRIPTION
Outputs json format instead of the standard text formatting
for these tools.

Addresses some of : TOOLS-626

Not sure if the arg parsing should go in **init** but it was the easiest way to get this going instead of adding it to each subcommand.
