### PR TITLE
fix compatibility with requests >=2.11.0

### DIFF
--- a/euca2ools/commands/s3/putobject.py
+++ b/euca2ools/commands/s3/putobject.py
@@ -101,7 +101,9 @@ class PutObject(S3Request, FileTransferProgressBarMixin):
     def main(self):
         self.preprocess()
         source = self.args['source']
-        self.headers['Content-Length'] = source.size
+
+        # For requests >=2.11.0 it requires headers to be either str or bytes
+        self.headers['Content-Length'] = bytes(source.size)
 
         # We do the upload in another thread so the main thread can show a
         # progress bar.


### PR DESCRIPTION
There is an issue starting from requests >=2.11.0

> $ euca-upload-bundle -m rh6.7_15-09-16_0100.img.manifest.xml -b images3
> requestbuilder.exceptions.ClientError: Header value 10485760 must be of type str or bytes, not <type 'int'>

here are two excerpts

```
diff --git a/docs/api.rst b/docs/api.rst
index 59b0523..08e2b6e 100644
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -258,6 +258,10 @@ Behavioural Changes

 * Keys in the ``headers`` dictionary are now native strings on all Python
   versions, i.e. bytestrings on Python 2 and unicode on Python 3. If the
-  keys are not native strings (unicode on Python2 or bytestrings on Python 3)
+  keys are not native strings (unicode on Python 2 or bytestrings on Python 3)
   they will be converted to the native string type assuming UTF-8 encoding.

+* Values in the ``headers`` dictionary should always be strings. This has
+  been the project's position since before 1.0 but a recent change
+  (since version 2.11.0) enforces this more strictly. It's advised to avoid
+  passing header values as unicode when possible.
```

and here

```
diff --git a/tests/test_structures.py b/tests/test_structures.py
index 1c332bb..e4d2459 100644
--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -713,10 +731,33 @@ def to_native_string(string, encoding='ascii'):
     return out


-def urldefragauth(url):
-    """
-    Given a url remove the fragment and the authentication part
+# Moved outside of function to avoid recompile every call
+_CLEAN_HEADER_REGEX_BYTE = re.compile(b'^\\S[^\\r\\n]*$|^$')
+_CLEAN_HEADER_REGEX_STR = re.compile(r'^\S[^\r\n]*$|^$')
+
+def check_header_validity(header):
+    """Verifies that header value is a string which doesn't contain
+    leading whitespace or return characters. This prevents unintended
+    header injection.
+
+    :param header: tuple, in the format (name, value).
     """
+    name, value = header
+
+    if isinstance(value, bytes):
+        pat = _CLEAN_HEADER_REGEX_BYTE
+    else:
+        pat = _CLEAN_HEADER_REGEX_STR
+    try:
+        if not pat.match(value):
+            raise InvalidHeader("Invalid return character or leading space in header: %s" % name)
+    except TypeError:
+        raise InvalidHeader("Header value %s must be of type str or bytes, "
+                            "not %s" % (value, type(value)))
+
+
+def urldefragauth(url):
+    """Given a url remove the fragment and the authentication part"""
     scheme, netloc, path, params, query, fragment = urlparse(url)

     # see func:`prepend_scheme_if_needed`
```

I cannot change the behaviours for _FileObjectExtent_, because its _size_ parameter is used for comparison. Therefore I construct bytes directly in _PutObject_ .
